### PR TITLE
Implement non-blocking commissioning LED fade

### DIFF
--- a/codex-test.ino
+++ b/codex-test.ino
@@ -126,6 +126,83 @@ constexpr uint32_t kRelayPulseDurationMs = 1000;
 bool relayPulseActive = false;
 uint32_t relayPulseStartMs = 0;
 
+enum class StatusLedMode : uint8_t {
+  kOff,
+  kSolid,
+  kFade,
+};
+
+constexpr uint8_t kStatusLedFadeMin = 0;
+constexpr uint8_t kStatusLedFadeMax = 255;
+constexpr uint8_t kStatusLedFadeStep = 5;
+constexpr uint32_t kStatusLedFadeIntervalMs = 15;
+
+StatusLedMode statusLedMode = StatusLedMode::kOff;
+int statusLedCurrentValue = -1;
+uint8_t statusLedSolidValue = 0;
+uint8_t statusLedFadeValue = kStatusLedFadeMin;
+int statusLedFadeDirection = 1;
+uint32_t statusLedLastUpdateMs = 0;
+
+bool lastCommissionedState = false;
+bool commissioningInfoLogged = false;
+uint32_t lastCommissioningLogMs = 0;
+uint32_t lastCommissioningWindowMs = 0;
+
+void WriteStatusLed(uint8_t value) {
+  if (statusLedCurrentValue != value) {
+    analogWrite(statusPin, value);
+    statusLedCurrentValue = value;
+  }
+}
+
+void SetStatusLedOff() {
+  statusLedMode = StatusLedMode::kOff;
+  WriteStatusLed(kStatusLedFadeMin);
+}
+
+void SetStatusLedSolid(bool on) {
+  statusLedMode = StatusLedMode::kSolid;
+  statusLedSolidValue = on ? kStatusLedFadeMax : kStatusLedFadeMin;
+  WriteStatusLed(statusLedSolidValue);
+}
+
+void StartStatusLedFade() {
+  statusLedMode = StatusLedMode::kFade;
+  statusLedFadeValue = kStatusLedFadeMin;
+  statusLedFadeDirection = 1;
+  statusLedLastUpdateMs = millis();
+  WriteStatusLed(statusLedFadeValue);
+}
+
+void ServiceStatusLed() {
+  if (statusLedMode != StatusLedMode::kFade) {
+    if (statusLedMode == StatusLedMode::kSolid) {
+      WriteStatusLed(statusLedSolidValue);
+    }
+    return;
+  }
+
+  const uint32_t now = millis();
+  if (now - statusLedLastUpdateMs < kStatusLedFadeIntervalMs) {
+    return;
+  }
+
+  statusLedLastUpdateMs = now;
+  int nextValue = static_cast<int>(statusLedFadeValue) + statusLedFadeDirection * kStatusLedFadeStep;
+
+  if (nextValue >= kStatusLedFadeMax) {
+    nextValue = kStatusLedFadeMax;
+    statusLedFadeDirection = -1;
+  } else if (nextValue <= kStatusLedFadeMin) {
+    nextValue = kStatusLedFadeMin;
+    statusLedFadeDirection = 1;
+  }
+
+  statusLedFadeValue = static_cast<uint8_t>(nextValue);
+  WriteStatusLed(statusLedFadeValue);
+}
+
 void StartRelayPulse() {
   relayPulseStartMs = millis();
   relayPulseActive = true;
@@ -176,7 +253,7 @@ void setup() {
   pinMode(onoffPin, OUTPUT);
   digitalWrite(onoffPin, LOW);
   pinMode(statusPin, OUTPUT);
-  digitalWrite(statusPin, LOW);
+  SetStatusLedOff();
 
   Serial.begin(115200);
 
@@ -206,12 +283,13 @@ void setup() {
   // Matter beginning - Last step, after all EndPoints are initialized
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
-  if (Matter.isDeviceCommissioned()) {
+  lastCommissionedState = Matter.isDeviceCommissioned();
+  if (lastCommissionedState) {
     Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf("Initial state: %s\r\n", OnOffPlugin.getOnOff() ? "ON" : "OFF");
     OnOffPlugin.updateAccessory();  // configure the Plugin based on initial state
     relayPulsingEnabled = true;
-    digitalWrite(statusPin, HIGH);
+    SetStatusLedSolid(true);
   } else {
 #if CONFIG_ENABLE_CHIPOBLE
     Serial.println("Opening commissioning window over BLE...");
@@ -221,6 +299,10 @@ void setup() {
     );
 #endif
     EnsureCommissioningWindowOpen();
+    StartStatusLedFade();
+    commissioningInfoLogged = false;
+    lastCommissioningLogMs = millis();
+    lastCommissioningWindowMs = millis();
   }
 
   Serial.println(
@@ -234,35 +316,51 @@ void loop() {
   // which prevents the node from completing the commissioning handshake.
   PumpMatterStack(Matter);
   ServiceRelayPulse();
+  ServiceStatusLed();
 
   // Check Matter Plugin Commissioning state, which may change during execution of loop()
-  if (!Matter.isDeviceCommissioned()) {
-    relayPulsingEnabled = false;
-    digitalWrite(statusPin, LOW);
-    EnsureCommissioningWindowOpen();
-    Serial.println("");
-    Serial.println("Matter Node is not commissioned yet.");
-    Serial.println("Initiate the device discovery in your Matter environment.");
-    Serial.println("Commission it to your Matter hub with the manual pairing code or QR code");
-    Serial.printf("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
-    Serial.printf("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
-    // waits for Matter Plugin Commissioning.
-    uint32_t timeCount = 0;
-    while (!Matter.isDeviceCommissioned()) {
-      PumpMatterStack(Matter);
+  const bool commissioned = Matter.isDeviceCommissioned();
+  if (commissioned != lastCommissionedState) {
+    lastCommissionedState = commissioned;
+    if (commissioned) {
+      Serial.printf("Initial state: %s\r\n", OnOffPlugin.getOnOff() ? "ON" : "OFF");
+      OnOffPlugin.updateAccessory();  // configure the Plugin based on initial state
+      Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
+      relayPulsingEnabled = true;
+      SetStatusLedSolid(true);
+      commissioningInfoLogged = false;
+    } else {
+      relayPulsingEnabled = false;
+      StartStatusLedFade();
+      commissioningInfoLogged = false;
+      lastCommissioningLogMs = 0;
+      lastCommissioningWindowMs = millis();
       EnsureCommissioningWindowOpen();
-      ServiceRelayPulse();
-      digitalWrite(statusPin, LOW);
-      delay(100);
-      if ((timeCount++ % 50) == 0) {  // 50*100ms = 5 sec
-        Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
-      }
     }
-    Serial.printf("Initial state: %s\r\n", OnOffPlugin.getOnOff() ? "ON" : "OFF");
-    OnOffPlugin.updateAccessory();  // configure the Plugin based on initial state
-    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
-    relayPulsingEnabled = true;
-    digitalWrite(statusPin, HIGH);
+  }
+
+  if (!commissioned) {
+    const uint32_t commissioningNow = millis();
+    if (!commissioningInfoLogged) {
+      Serial.println("");
+      Serial.println("Matter Node is not commissioned yet.");
+      Serial.println("Initiate the device discovery in your Matter environment.");
+      Serial.println("Commission it to your Matter hub with the manual pairing code or QR code");
+      Serial.printf("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
+      Serial.printf("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
+      commissioningInfoLogged = true;
+      lastCommissioningLogMs = commissioningNow;
+    }
+
+    if ((commissioningNow - lastCommissioningWindowMs) >= 1000) {
+      EnsureCommissioningWindowOpen();
+      lastCommissioningWindowMs = commissioningNow;
+    }
+
+    if ((commissioningNow - lastCommissioningLogMs) >= 5000) {
+      Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
+      lastCommissioningLogMs = commissioningNow;
+    }
   }
 
   // Check if the button has been pressed
@@ -286,7 +384,7 @@ void loop() {
       RequestDecommission();
       button_long_press_handled = true;
       button_time_stamp = now;  // avoid running decommissioning again while still pressed
-      digitalWrite(statusPin, LOW);
+      SetStatusLedOff();
     }
   }
 
@@ -303,7 +401,4 @@ void loop() {
     }
   }
 
-  if (!Matter.isDeviceCommissioned()) {
-    digitalWrite(statusPin, LOW);
-  }
 }


### PR DESCRIPTION
## Summary
- add a PWM-driven status LED state machine that fades the status LED while the device is commissioning
- refactor the commissioning logic to remove the blocking wait loop and keep periodic status updates running in the background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea6ac6794833091b8bc03a698ff40